### PR TITLE
Keep top level dependencies

### DIFF
--- a/src/ConsoleApp/IProjectConverter.cs
+++ b/src/ConsoleApp/IProjectConverter.cs
@@ -19,5 +19,7 @@ namespace PackagesConfigProjectConverter
         public ILog Log { get; set; }
 
         public string RepositoryRoot { get; set; }
+
+        public bool TrimPackages { get; set; }
     }
 }

--- a/src/ConsoleApp/Program.cs
+++ b/src/ConsoleApp/Program.cs
@@ -72,7 +72,8 @@ namespace PackagesConfigProjectConverter
                 RepositoryRoot = arguments.RepoRoot,
                 Include = arguments.Include.ToRegex(),
                 Exclude = arguments.Exclude.ToRegex(),
-                Log = Log
+                Log = Log,
+                TrimPackages = arguments.Trim
             };
 
             Log.Info($" RepositoryRoot: '{settings.RepositoryRoot}'");

--- a/src/ConsoleApp/ProgramArguments.cs
+++ b/src/ConsoleApp/ProgramArguments.cs
@@ -29,6 +29,9 @@ namespace PackagesConfigProjectConverter
         [Option('q', HelpText = "Verbose output")]
         public bool Quiete { get; set; }
 
+        [Option('t', HelpText = "Trim packages to top-level dependencies")]
+        public bool Trim { get; set; }
+
         [Option('v', HelpText = "Verbose output")]
         public bool Verbose { get; set; }
     }


### PR DESCRIPTION
This change keeps only the top level dependencies of a project instead of the full package graph.

For example, 
1. Project depends on packages `A` and `B` 
1. `A` depends on `B`

It is acceptable to produce `PackageReference` items for both `A` and `B` but it is preferable to produce a reference to `A` **only**  and let `B` get restored transitively.

Fixes #5