### PR TITLE
Ignore '_._' files

### DIFF
--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/after.csproj
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/after.csproj
@@ -36,7 +36,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" ExcludeAssets="Runtime, Compile" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" ExcludeAssets="Build" />
   </ItemGroup>

--- a/src/PackagesConfigConverter/PackageReference.cs
+++ b/src/PackagesConfigConverter/PackageReference.cs
@@ -64,10 +64,31 @@ namespace PackagesConfigConverter
                 return Array.Empty<string>();
             }
 
-            return new HashSet<string>(
-                Directory.EnumerateDirectories(RepositoryInstalledPath)
-                    .Select(i => i.Substring(i.LastIndexOf(Path.DirectorySeparatorChar) + 1)),
-                StringComparer.OrdinalIgnoreCase);
+            var folderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string dir in Directory.EnumerateDirectories(RepositoryInstalledPath))
+            {
+                if (HasAnyRealFiles(dir))
+                {
+                    string dirName = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                    folderNames.Add(dirName);
+                }
+            }
+
+            return folderNames;
+
+            static bool HasAnyRealFiles(string dir)
+            {
+                // Ignore the special "_._" file.
+                foreach (string file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
+                {
+                    if (!Path.GetFileName(file).Equals("_._"))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Some packages like `Microsoft.NET.Test.Sdk` have empty "_._" files under lib, which should not be considered.

```
>dir /s /b Microsoft.NET.Test.Sdk.17.6.0\lib
D:\Code\PackagesConfigConverter\src\PackagesConfigConverter.UnitTests\bin\Debug\net472\_work\packages\Microsoft.NET.Test.Sdk.17.6.0\lib\net462
D:\Code\PackagesConfigConverter\src\PackagesConfigConverter.UnitTests\bin\Debug\net472\_work\packages\Microsoft.NET.Test.Sdk.17.6.0\lib\netcoreapp3.1
D:\Code\PackagesConfigConverter\src\PackagesConfigConverter.UnitTests\bin\Debug\net472\_work\packages\Microsoft.NET.Test.Sdk.17.6.0\lib\net462\_._
D:\Code\PackagesConfigConverter\src\PackagesConfigConverter.UnitTests\bin\Debug\net472\_work\packages\Microsoft.NET.Test.Sdk.17.6.0\lib\netcoreapp3.1\_._`
```

The updated UT expectation shows the (desired) impact of the change