### PR TITLE
Replace log4net with Serilog

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,10 +4,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="log4net" Version="2.0.17" />
     <PackageVersion Include="Microsoft.Build" Version="17.10.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="NuGet.Commands" Version="6.10.1" />
+    <PackageVersion Include="Serilog" Version="4.0.1" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/PackagesConfigConverter.UnitTests/E2ETests.cs
+++ b/src/PackagesConfigConverter.UnitTests/E2ETests.cs
@@ -2,8 +2,6 @@
 //
 // Licensed under the MIT license.
 
-using log4net;
-using log4net.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -108,7 +106,7 @@ namespace PackagesConfigConverter.UnitTests
             var converterSettings = new ProjectConverterSettings()
             {
                 Include = ConverterInclude,
-                Log = new TestLog(TestOutputHelper),
+                Log = new XUnitLogger(TestOutputHelper),
                 RepositoryRoot = workingDir,
             };
             var converter = new ProjectConverter(converterSettings);
@@ -120,110 +118,6 @@ namespace PackagesConfigConverter.UnitTests
             string expectedProjectContent = File.ReadAllText(Path.Combine(testCaseDir, AfterProjectName));
             string actualProjectContent = File.ReadAllText(Path.Combine(workingDir, BeforeProjectName));
             Assert.Equal(expectedProjectContent, actualProjectContent);
-        }
-
-        private sealed class TestLog : ILog
-        {
-            private const string DebugLevel = "Debug";
-            private const string ErrorLevel = "Error";
-            private const string FatalLevel = "Fatal";
-            private const string InfoLevel = "Info";
-            private const string WarnLevel = "Warn";
-
-            private readonly ITestOutputHelper _testOutputHelper;
-
-            public TestLog(ITestOutputHelper testOutputHelper)
-            {
-                _testOutputHelper = testOutputHelper;
-            }
-
-            public bool IsDebugEnabled => true;
-
-            public bool IsInfoEnabled => true;
-
-            public bool IsWarnEnabled => true;
-
-            public bool IsErrorEnabled => true;
-
-            public bool IsFatalEnabled => true;
-
-            public ILogger Logger => throw new NotImplementedException();
-
-            public void Debug(object message) => Log(DebugLevel, message);
-
-            public void Debug(object message, Exception exception) => Log(DebugLevel, message, exception);
-
-            public void DebugFormat(string format, params object[] args) => Log(DebugLevel, format, args);
-
-            public void DebugFormat(string format, object arg0) => Log(DebugLevel, string.Format(format, arg0));
-
-            public void DebugFormat(string format, object arg0, object arg1) => Log(DebugLevel, string.Format(format, arg0, arg1));
-
-            public void DebugFormat(string format, object arg0, object arg1, object arg2) => Log(DebugLevel, string.Format(format, arg0, arg2));
-
-            public void DebugFormat(IFormatProvider provider, string format, params object[] args) => Log(DebugLevel, string.Format(provider, format, args));
-
-            public void Error(object message) => Log(ErrorLevel, message);
-
-            public void Error(object message, Exception exception) => Log(ErrorLevel, message, exception);
-
-            public void ErrorFormat(string format, params object[] args) => Log(ErrorLevel, format, args);
-
-            public void ErrorFormat(string format, object arg0) => Log(ErrorLevel, string.Format(format, arg0));
-
-            public void ErrorFormat(string format, object arg0, object arg1) => Log(ErrorLevel, string.Format(format, arg0, arg1));
-
-            public void ErrorFormat(string format, object arg0, object arg1, object arg2) => Log(ErrorLevel, string.Format(format, arg0, arg2));
-
-            public void ErrorFormat(IFormatProvider provider, string format, params object[] args) => Log(ErrorLevel, string.Format(provider, format, args));
-
-            public void Fatal(object message) => Log(FatalLevel, message);
-
-            public void Fatal(object message, Exception exception) => Log(FatalLevel, message, exception);
-
-            public void FatalFormat(string format, params object[] args) => Log(FatalLevel, format, args);
-
-            public void FatalFormat(string format, object arg0) => Log(FatalLevel, string.Format(format, arg0));
-
-            public void FatalFormat(string format, object arg0, object arg1) => Log(FatalLevel, string.Format(format, arg0, arg1));
-
-            public void FatalFormat(string format, object arg0, object arg1, object arg2) => Log(FatalLevel, string.Format(format, arg0, arg2));
-
-            public void FatalFormat(IFormatProvider provider, string format, params object[] args) => Log(FatalLevel, string.Format(provider, format, args));
-
-            public void Info(object message) => Log(InfoLevel, message);
-
-            public void Info(object message, Exception exception) => Log(InfoLevel, message, exception);
-
-            public void InfoFormat(string format, params object[] args) => Log(InfoLevel, format, args);
-
-            public void InfoFormat(string format, object arg0) => Log(InfoLevel, string.Format(format, arg0));
-
-            public void InfoFormat(string format, object arg0, object arg1) => Log(InfoLevel, string.Format(format, arg0, arg1));
-
-            public void InfoFormat(string format, object arg0, object arg1, object arg2) => Log(InfoLevel, string.Format(format, arg0, arg2));
-
-            public void InfoFormat(IFormatProvider provider, string format, params object[] args) => Log(InfoLevel, string.Format(provider, format, args));
-
-            public void Warn(object message) => Log(WarnLevel, message);
-
-            public void Warn(object message, Exception exception) => Log(WarnLevel, message, exception);
-
-            public void WarnFormat(string format, params object[] args) => Log(WarnLevel, format, args);
-
-            public void WarnFormat(string format, object arg0) => Log(WarnLevel, string.Format(format, arg0));
-
-            public void WarnFormat(string format, object arg0, object arg1) => Log(WarnLevel, string.Format(format, arg0, arg1));
-
-            public void WarnFormat(string format, object arg0, object arg1, object arg2) => Log(WarnLevel, string.Format(format, arg0, arg2));
-
-            public void WarnFormat(IFormatProvider provider, string format, params object[] args) => Log(WarnLevel, string.Format(provider, format, args));
-
-            private void Log(string level, object message) => _testOutputHelper.WriteLine($"[{level}] {message}");
-
-            private void Log(string level, object message, Exception exception) => _testOutputHelper.WriteLine($"[{level}] {message}. Exception: {exception}");
-
-            private void Log(string level, string format, params object[] args) => _testOutputHelper.WriteLine($"[{level}] {format}", args);
         }
     }
 }

--- a/src/PackagesConfigConverter.UnitTests/XUnitLogger.cs
+++ b/src/PackagesConfigConverter.UnitTests/XUnitLogger.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Jeff Kluge. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using System;
+using Xunit.Abstractions;
+
+namespace PackagesConfigConverter.UnitTests
+{
+    internal sealed class XUnitLogger : ILogger
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public XUnitLogger(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => _testOutputHelper.WriteLine(formatter(state, exception));
+    }
+}

--- a/src/PackagesConfigConverter/PackagesConfigConverter.csproj
+++ b/src/PackagesConfigConverter/PackagesConfigConverter.csproj
@@ -5,9 +5,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
-    <PackageReference Include="log4net" />
     <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="NuGet.Commands" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.Async" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="PackagesConfigConverter.UnitTests" />

--- a/src/PackagesConfigConverter/ProjectConverterSettings.cs
+++ b/src/PackagesConfigConverter/ProjectConverterSettings.cs
@@ -2,7 +2,7 @@
 //
 // Licensed under the MIT license.
 
-using log4net;
+using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
 
 namespace PackagesConfigConverter
@@ -13,7 +13,7 @@ namespace PackagesConfigConverter
 
         public Regex Include { get; set; }
 
-        public ILog Log { get; set; }
+        public ILogger Log { get; set; }
 
         public string NuGetConfigPath { get; set; } = "(Default)";
 

--- a/src/PackagesConfigConverter/Properties/AssemblyInfo.cs
+++ b/src/PackagesConfigConverter/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) Jeff Kluge. All rights reserved.
-//
-// Licensed under the MIT license.
-
-using log4net.Config;
-
-[assembly: XmlConfigurator(Watch = true)]


### PR DESCRIPTION
Previously log4net was being used but there is no log4net config file so no logging ever happened.

I took the opportunity to just migrate to a more modern logger, Serilog.

I also added a console logger with a min log level of Info so there's some kind of progress indication, and the file logger defaults to debug level, if a log file is provided.