### PR TITLE
Reuse package information for unique packages

### DIFF
--- a/src/PackagesConfigConverter/PackageInfo.cs
+++ b/src/PackagesConfigConverter/PackageInfo.cs
@@ -2,11 +2,8 @@
 //
 // Licensed under the MIT license.
 
-using Microsoft.Build.Construction;
-using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
-using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,41 +11,28 @@ using System.Linq;
 
 namespace PackagesConfigConverter
 {
-    internal class PackageReference : NuGet.Packaging.PackageReference
+    internal sealed class PackageInfo
     {
         private IReadOnlyCollection<string> _installedPackageFolderNames;
 
-        public PackageReference(PackageIdentity identity, NuGetFramework targetFramework, bool userInstalled, bool developmentDependency, bool requireReinstallation, VersionRange allowedVersions, PackagePathResolver packagePathResolver, VersionFolderPathResolver versionFolderPathResolver)
-            : base(identity, targetFramework, userInstalled, developmentDependency, requireReinstallation, allowedVersions)
+        public PackageInfo(PackageIdentity identity, PackagePathResolver packagePathResolver, VersionFolderPathResolver versionFolderPathResolver)
         {
-            InstalledPackageFilePath = PackagePathHelper.GetInstalledPackageFilePath(PackageIdentity, packagePathResolver ?? throw new ArgumentNullException(nameof(packagePathResolver)));
+            Identity = identity;
+
+            InstalledPackageFilePath = PackagePathHelper.GetInstalledPackageFilePath(Identity, packagePathResolver ?? throw new ArgumentNullException(nameof(packagePathResolver)));
 
             RepositoryInstalledPath = Path.GetDirectoryName(InstalledPackageFilePath);
 
             GlobalInstalledPath = Path.GetFullPath(versionFolderPathResolver.GetInstallPath(identity.Id, identity.Version));
         }
 
-        public IEnumerable<ProjectElement> AllElements => AnalyzerItems.Cast<ProjectElement>().Concat(AssemblyReferences).Concat(Imports);
-
-        public List<ProjectItemElement> AnalyzerItems { get; } = new ();
-
-        public List<ProjectItemElement> AssemblyReferences { get; } = new ();
-
-        public bool GeneratePathProperty { get; set; }
-
         public string GlobalInstalledPath { get; }
-
-        public List<ProjectImportElement> Imports { get; } = new ();
 
         public string InstalledPackageFilePath { get; }
 
         public IReadOnlyCollection<string> InstalledPackageFolderNames => _installedPackageFolderNames ??= GetPackageFolderNames();
 
-        public bool IsMissingTransitiveDependency { get; set; }
-
-        public string PackageId => PackageIdentity.Id;
-
-        public NuGetVersion PackageVersion => PackageIdentity.Version;
+        public PackageIdentity Identity { get; }
 
         public string RepositoryInstalledPath { get; }
 

--- a/src/PackagesConfigConverter/PackageInfoFactory.cs
+++ b/src/PackagesConfigConverter/PackageInfoFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Jeff Kluge. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using System.Collections.Concurrent;
+
+namespace PackagesConfigConverter
+{
+    internal sealed class PackageInfoFactory
+    {
+        private readonly PackagePathResolver _packagePathResolver;
+        private readonly VersionFolderPathResolver _versionFolderPathResolver;
+        private readonly ConcurrentDictionary<PackageIdentity, PackageInfo> _packages = new ();
+
+        public PackageInfoFactory(PackagePathResolver packagePathResolver, VersionFolderPathResolver versionFolderPathResolver)
+        {
+            _packagePathResolver = packagePathResolver;
+            _versionFolderPathResolver = versionFolderPathResolver;
+        }
+
+        public PackageInfo GetPackageInfo(PackageIdentity identity) => _packages.GetOrAdd(identity, id => new PackageInfo(id, _packagePathResolver, _versionFolderPathResolver));
+    }
+}

--- a/src/PackagesConfigConverter/PackageUsage.cs
+++ b/src/PackagesConfigConverter/PackageUsage.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Jeff Kluge. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using CommandLine;
+using Microsoft.Build.Construction;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PackagesConfigConverter
+{
+    internal sealed class PackageUsage
+    {
+        public PackageUsage(PackageIdentity identity, PackageInfo packageInfo, bool isDevelopmentDependency)
+        {
+            PackageInfo = packageInfo;
+            IsDevelopmentDependency = isDevelopmentDependency;
+        }
+
+        public PackageInfo PackageInfo { get; }
+
+        public bool IsDevelopmentDependency { get; }
+
+        public IEnumerable<ProjectElement> AllElements => AnalyzerItems.Cast<ProjectElement>().Concat(AssemblyReferences).Concat(Imports);
+
+        public List<ProjectItemElement> AnalyzerItems { get; } = new ();
+
+        public List<ProjectItemElement> AssemblyReferences { get; } = new ();
+
+        public List<ProjectImportElement> Imports { get; } = new ();
+
+        public bool GeneratePathProperty { get; set; }
+
+        public bool IsMissingTransitiveDependency { get; set; }
+
+        public string PackageId => PackageInfo.Identity.Id;
+
+        public NuGetVersion PackageVersion => PackageInfo.Identity.Version;
+    }
+}


### PR DESCRIPTION
Refactor to tease apart `PackageReference` into `PackageInfo` (information about the package itself) and `PackageUsage` (information about how a package is used in a project). `PackageInfo` can be reused across projects for unique packages.

It also helps with the confusion of `PackageReference : NuGet.Packaging.PackageReference`.

Besides being cleaner and paving the way for some other changes I'm working on, this helps improve performance for a specific repo I'm testing with from 1 min to 45 secs.