### PR TITLE
Provide project's TargetFramework

### DIFF
--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/after.csproj
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/after.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" ExcludeAssets="Build" />

--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/before.csproj
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/before.csproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props')" />
-  <Import Project="..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props')" />
+  <Import Project="..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.props" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -31,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeCoverage.17.6.0\lib\net462\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.3.1.1\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -63,11 +67,14 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\..\..\..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets')" />
-  <Import Project="..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\..\..\..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.targets" Condition="Exists('..\packages\Microsoft.CodeCoverage.17.6.0\build\netstandard2.0\Microsoft.CodeCoverage.targets')" />
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.17.6.0\build\net462\Microsoft.NET.Test.Sdk.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.3.1.1\build\net462\MSTest.TestAdapter.targets')" />
 </Project>

--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/packages.config
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/MSTest/packages.config
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.CodeCoverage" version="17.6.0" targetFramework="net462" />
   <package id="Microsoft.NET.Test.Sdk" version="17.6.0" targetFramework="net462" />
   <package id="MSTest.TestAdapter" version="3.1.1" targetFramework="net462" />
   <package id="MSTest.TestFramework" version="3.1.1" targetFramework="net462" />

--- a/src/PackagesConfigConverter/Program.cs
+++ b/src/PackagesConfigConverter/Program.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading;
 using CommandLine;
 using Microsoft.Extensions.Logging;
+using NuGet.Frameworks;
 using Serilog;
 using Serilog.Events;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -69,6 +70,11 @@ namespace PackagesConfigConverter
                 Log = logger,
                 TrimPackages = arguments.Trim,
             };
+
+            if (arguments.DefaultTargetFramework != null)
+            {
+                settings.DefaultTargetFramework = NuGetFramework.Parse(arguments.DefaultTargetFramework);
+            }
 
             logger.LogInformation($" RepositoryRoot: '{settings.RepositoryRoot}'");
             logger.LogInformation($"  Include regex: '{settings.Include}'");

--- a/src/PackagesConfigConverter/ProgramArguments.cs
+++ b/src/PackagesConfigConverter/ProgramArguments.cs
@@ -31,5 +31,8 @@ namespace PackagesConfigConverter
 
         [Option('y', HelpText = "Suppresses prompting to confirm you want to convert the repository")]
         public bool Yes { get; set; }
+
+        [Option('f', HelpText = "The default target framework to assume if not defined in the project")]
+        public string DefaultTargetFramework { get; set; }
     }
 }

--- a/src/PackagesConfigConverter/ProjectConverterSettings.cs
+++ b/src/PackagesConfigConverter/ProjectConverterSettings.cs
@@ -4,6 +4,7 @@
 
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using NuGet.Frameworks;
 
 namespace PackagesConfigConverter
 {
@@ -20,5 +21,7 @@ namespace PackagesConfigConverter
         public string RepositoryRoot { get; set; }
 
         public bool TrimPackages { get; set; }
+
+        public NuGetFramework DefaultTargetFramework { get; set; } = FrameworkConstants.CommonFrameworks.Net45;
     }
 }


### PR DESCRIPTION
Currently the TF is being hard-coded to net45, which is causing some package dependencies to not get picked up correctly.

This change attempts to find the project's TF, and allows the user to provide a default if, for example, the TF is defined in some global props file somewhere.