### PR TITLE
Consume LockFileTargetLibrary for a filtered list of files the package has for a project

### DIFF
--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/ExcludeAnalyzers/after.csproj
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/ExcludeAnalyzers/after.csproj
@@ -30,16 +30,21 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
-    <PackageReference Include="Microsoft.CodeCoverage" Version="17.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" ExcludeAssets="Build, Analyzers" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SomeCompile.cs" />

--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/ExcludeAnalyzers/before.csproj
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/ExcludeAnalyzers/before.csproj
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{526743F1-40C3-4E9D-A23B-927EE3FC8583}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SomeProject</RootNamespace>
+    <AssemblyName>SomeProject</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.8.0.0\lib\net462\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="SomeCompile.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="SomeContent.txt" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/ExcludeAnalyzers/packages.config
+++ b/src/PackagesConfigConverter.UnitTests/TestData/E2ETests/ExcludeAnalyzers/packages.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="8.0.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
+</packages>

--- a/src/PackagesConfigConverter/PackageInfo.cs
+++ b/src/PackagesConfigConverter/PackageInfo.cs
@@ -3,9 +3,7 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 
@@ -13,8 +11,6 @@ namespace PackagesConfigConverter
 {
     internal sealed class PackageInfo
     {
-        private IReadOnlyCollection<string> _installedPackageFolderNames;
-
         public PackageInfo(PackageIdentity identity, PackagePathResolver packagePathResolver, VersionFolderPathResolver versionFolderPathResolver)
         {
             Identity = identity;
@@ -24,55 +20,18 @@ namespace PackagesConfigConverter
             RepositoryInstalledPath = Path.GetDirectoryName(InstalledPackageFilePath);
 
             GlobalInstalledPath = Path.GetFullPath(versionFolderPathResolver.GetInstallPath(identity.Id, identity.Version));
+
+            HasAnalyzers = Directory.Exists(Path.Combine(RepositoryInstalledPath, "analyzers"));
         }
 
         public string GlobalInstalledPath { get; }
 
         public string InstalledPackageFilePath { get; }
 
-        public IReadOnlyCollection<string> InstalledPackageFolderNames => _installedPackageFolderNames ??= GetPackageFolderNames();
-
         public PackageIdentity Identity { get; }
 
         public string RepositoryInstalledPath { get; }
 
-        public bool HasFolder(string name)
-        {
-            return InstalledPackageFolderNames.Contains(name);
-        }
-
-        private IReadOnlyCollection<string> GetPackageFolderNames()
-        {
-            if (RepositoryInstalledPath == null)
-            {
-                return Array.Empty<string>();
-            }
-
-            var folderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (string dir in Directory.EnumerateDirectories(RepositoryInstalledPath))
-            {
-                if (HasAnyRealFiles(dir))
-                {
-                    string dirName = dir.Substring(dir.LastIndexOf(Path.DirectorySeparatorChar) + 1);
-                    folderNames.Add(dirName);
-                }
-            }
-
-            return folderNames;
-
-            static bool HasAnyRealFiles(string dir)
-            {
-                // Ignore the special "_._" file.
-                foreach (string file in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
-                {
-                    if (!Path.GetFileName(file).Equals("_._"))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-        }
+        public bool HasAnalyzers { get; }
     }
 }


### PR DESCRIPTION
Previously is a package had assets which were only for a specific TF which isn't the TF that the project uses, the converter would add an exclusion of that asset type unecessarily.

This change uses the information from nuget, in particular `LockFileTargetLibrary`, to get a filtered view of the assets specific to what the project would actually consume.

The only hack is with analyzers, which aren't represented in `LockFileTargetLibrary`. Those aren't TF-specific anyway though, so we can use the "does the dir exist" mechanism for that.

Also a minor improvement is to converge inclusions and exclusions to "All" if they match everything the package contains. ie if the flags was going to be "Compile, Runtime" but that package only had those assets (no build, no analyzers, etc), then the flags is upgraded to "All".