### PR TITLE
Add option to use MSBuild's graph to discover projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Build" Version="17.10.4" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="NuGet.Commands" Version="6.10.1" />

--- a/src/PackagesConfigConverter/PackagesConfigConverter.csproj
+++ b/src/PackagesConfigConverter/PackagesConfigConverter.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
-    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="Serilog" />

--- a/src/PackagesConfigConverter/ProgramArguments.cs
+++ b/src/PackagesConfigConverter/ProgramArguments.cs
@@ -17,6 +17,9 @@ namespace PackagesConfigConverter
         [Option('i', HelpText = "Regex for project files to include", MetaValue = "regex")]
         public string Include { get; set; }
 
+        [Option('g', HelpText = "Whether to use the MSBuild graph to discover project files")]
+        public bool Graph { get; set; }
+
         [Option('l', HelpText = "Log file to write to", MetaValue = "log")]
         public string LogFile { get; set; }
 

--- a/src/PackagesConfigConverter/ProjectConverterSettings.cs
+++ b/src/PackagesConfigConverter/ProjectConverterSettings.cs
@@ -14,6 +14,8 @@ namespace PackagesConfigConverter
 
         public Regex Include { get; set; }
 
+        public bool Graph { get; set; }
+
         public ILogger Log { get; set; }
 
         public string NuGetConfigPath { get; set; } = "(Default)";


### PR DESCRIPTION
Add option to use MSBuild's graph to discover projects

Unfortunately many repos have unbuilt projects, so this option helps scope the conversion just to projects which actually build when building from the repo root.

This change also uses MSBuildLocator to load the MSBuild assemblies to ensure better compatibility.